### PR TITLE
Handle extraneous whitespace in repo IDs

### DIFF
--- a/src/io.py
+++ b/src/io.py
@@ -156,13 +156,19 @@ class HfRepo:
         >>> model_repo.url()
         'hf://huggingface/CodeBERTa-small-v1'
         """
+        repo_id = repo_id.strip()
         parts = repo_id.split("/")
-        if len(parts) != 2 or not parts[0] or not parts[1]:
+        if len(parts) != 2:
             raise ValueError(
                 f"Invalid repository ID: '{repo_id}'. Expected format: 'entity/name'"
             )
 
-        entity, name = parts
+        entity, name = (part.strip() for part in parts)
+        if not entity or not name:
+            raise ValueError(
+                f"Invalid repository ID: '{repo_id}'. Expected format: 'entity/name'"
+            )
+
         return HfRepo(entity=entity, name=name, type=type, internal=False)
 
 

--- a/src/tests/test_io.py
+++ b/src/tests/test_io.py
@@ -86,6 +86,13 @@ class TestHfRepo:
         assert repo.internal is False
         assert repo.url() == expected_url
 
+    def test_from_repo_id_strips_whitespace(self):
+        """Leading and trailing whitespace in repo_id should be ignored."""
+        repo = HfRepo.from_repo_id("  org / repo  ")
+        assert repo.entity == "org"
+        assert repo.name == "repo"
+        assert repo.path() == "datasets/org/repo"
+
     @pytest.mark.parametrize(
         "invalid_repo_id",
         [


### PR DESCRIPTION
## Summary
- strip whitespace when parsing repo IDs in `HfRepo.from_repo_id`
- test that repository IDs with leading/trailing spaces are normalized

## Testing
- `PYTHONPATH=/workspace/biolm-demo pytest src/tests/test_io.py -q`
- ❌ `pre-commit run --files src/io.py src/tests/test_io.py` *(missing dependency, unable to install pre-commit due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6dad9994832ea20cef4076af2d7c