### PR TITLE
Fix eval configs for 2bp motif tasks

### DIFF
--- a/src/utils/ray_utils.py
+++ b/src/utils/ray_utils.py
@@ -3,7 +3,6 @@ from typing import Any, TypeVar
 
 import ray
 from ray.util.placement_group import (
-    PlacementGroup,
     placement_group,
     remove_placement_group,
 )
@@ -150,16 +149,10 @@ def run_once_per_node(
         results = ray.get(futures)
         return results
     finally:
-        # Always clean up actors and placement group
-        _remove_actors_and_placement_group(actors, pg)
-
-
-def _remove_actors_and_placement_group(
-    actors: list[ray.actor.ActorHandle], pg: PlacementGroup
-) -> None:
-    for actor in actors:
-        ray.kill(actor)
-    remove_placement_group(pg)
+        # Clean up actors and placement group
+        for actor in actors:
+            ray.kill(actor)
+        remove_placement_group(pg)
 
 
 def run_once_per_gpu(


### PR DESCRIPTION
This fixes a bug where 2bp motifs for donor/acceptor tasks were not being configured correctly (3bp masks were being used instead).  See here for details on mask tokens for each task: [plantcad/docs/zero-shot-eval.md](https://github.com/plantcad/plantcad/blob/dfd3f1cb08bdb707f5bee541531bc2cc5a2c130e/docs/zero-shot-eval.md).


I believe this might address the discrepancy in scores I noted before at https://github.com/plantcad/plantcad-dev/pull/26#issue-3478812316:

> These are all pretty close, though the difference between the acceptor/donor tasks at the bottom is maybe mildly concerning.