### PR TITLE
Add support for causal LMs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
       - name: Install dependencies
         run: |
-          uv sync --group dev
+          uv sync --group dev --extra cpu
       - name: Run pre-commit
         run: |
           uv run pre-commit run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ slurm = [
 filterwarnings = [
   "ignore:UPath 'hf' filesystem not explicitly implemented:UserWarning:upath.core",
 ]
-addopts = "--cov=src --cov-report=term-missing --cov-report=html"
+addopts = "-v --cov=src --cov-report=term-missing --cov-report=html"
 
 [tool.coverage.run]
 source = ["src"]

--- a/src/pipelines/plantcad2/evaluation/config.py
+++ b/src/pipelines/plantcad2/evaluation/config.py
@@ -43,12 +43,11 @@ class ModelConfig:
         description="Inference mode for motif tasks (only relevant for CLM models)",
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def set_default_name(cls, data: dict) -> dict:
-        if not data.get("name"):
-            data["name"] = data["path"]
-        return data
+    @model_validator(mode="after")
+    def set_default_name(self) -> Self:
+        if not self.name:
+            self.name = self.path
+        return self
 
 
 # Use kw_only to support required and optional fields in any order

--- a/src/pipelines/plantcad2/evaluation/config.yaml
+++ b/src/pipelines/plantcad2/evaluation/config.yaml
@@ -1,11 +1,23 @@
 # Pipeline configuration for PlantCAD2 zero-shot evaluation tasks
 
 executor:
-  prefix: s3://oa-plantcad-dev/pipelines/_dev_pc2_eval_20251117_r1
+  prefix: s3://oa-plantcad-dev/pipelines/_dev_pc2_eval_20251201_r5
   force_run_failed: true
 
 models:
-  - kuleshov-group/PlantCAD2-Small-l24-d0768
+  - path: kuleshov-group/PlantCAD2-Small-l24-d0768
+    type: mlm
+    context_length: 8192
+  - path: plantcad/marin_exp1729__pcv1_600m_c512__checkpoints
+    type: clm
+    context_length: 512
+    subfolder: local_store/checkpoints/plantcad-train-600m-r16-a1bc43/hf/step-26782
+  - path: kuleshov-group/PlantCaduceus_l20
+    type: mlm
+    context_length: 512
+  - path: kuleshov-group/PlantCaduceus_l32
+    type: mlm
+    context_length: 512
 
 compute:
   device: cuda
@@ -22,14 +34,14 @@ splits:
   # Acceptor splice site tasks
   - task: acceptor_core_noncore_classification
     split: test_maize
-  - task: acceptor_core_noncore_classification
-    split: test_tomato
+  # - task: acceptor_core_noncore_classification
+  #   split: test_tomato
   - task: acceptor_recovery
     split: test_maize
-  - task: acceptor_recovery
-    split: test_tomato
+  # - task: acceptor_recovery
+  #   split: test_tomato
 
-  # Conservation tasks
+  # # Conservation tasks
   - task: conservation_within_poaceae_non_tis
     split: test
   - task: conservation_within_andropogoneae
@@ -37,36 +49,36 @@ splits:
   - task: conservation_within_poaceae_tis
     split: test
 
-  # Structural variant task
-  - task: structural_variant_effect_prediction
-    split: test
+  # # Structural variant task
+  # - task: structural_variant_effect_prediction
+  #   split: test
 
-  # Donor splice site tasks
+  # # Donor splice site tasks
   - task: donor_core_noncore_classification
     split: test_maize
-  - task: donor_core_noncore_classification
-    split: test_tomato
+  # - task: donor_core_noncore_classification
+  #   split: test_tomato
   - task: donor_recovery
     split: test_maize
-  - task: donor_recovery
-    split: test_tomato
+  # - task: donor_recovery
+  #   split: test_tomato
 
-  # Translation initiation site (TIS) tasks
+  # # Translation initiation site (TIS) tasks
   - task: tis_core_noncore_classification
     split: test_maize
-  - task: tis_core_noncore_classification
-    split: test_tomato
+  # - task: tis_core_noncore_classification
+  #   split: test_tomato
   - task: tis_recovery
     split: test_maize
-  - task: tis_recovery
-    split: test_tomato
+  # - task: tis_recovery
+  #   split: test_tomato
 
-  # Translation termination site (TTS) tasks
+  # # Translation termination site (TTS) tasks
   - task: tts_core_noncore_classification
     split: test_maize
-  - task: tts_core_noncore_classification
-    split: test_tomato
+  # - task: tts_core_noncore_classification
+  #   split: test_tomato
   - task: tts_recovery
     split: test_maize
-  - task: tts_recovery
-    split: test_tomato
+  # - task: tts_recovery
+  #   split: test_tomato

--- a/src/pipelines/plantcad2/evaluation/config.yaml
+++ b/src/pipelines/plantcad2/evaluation/config.yaml
@@ -1,23 +1,37 @@
 # Pipeline configuration for PlantCAD2 zero-shot evaluation tasks
 
 executor:
-  prefix: s3://oa-plantcad-dev/pipelines/_dev_pc2_eval_20251201_r5
+  prefix: s3://oa-plantcad-dev/pipelines/_dev_pc2_eval_20251202_r1
   force_run_failed: true
 
 models:
-  - path: kuleshov-group/PlantCAD2-Small-l24-d0768
-    type: mlm
-    context_length: 8192
-  - path: plantcad/marin_exp1729__pcv1_600m_c512__checkpoints
-    type: clm
-    context_length: 512
-    subfolder: local_store/checkpoints/plantcad-train-600m-r16-a1bc43/hf/step-26782
+  # - path: kuleshov-group/PlantCAD2-Small-l24-d0768
+  #   type: mlm
+  #   context_length: 8192
   - path: kuleshov-group/PlantCaduceus_l20
     type: mlm
     context_length: 512
   - path: kuleshov-group/PlantCaduceus_l32
     type: mlm
     context_length: 512
+  - path: plantcad/marin_exp1729__pcv1_600m_c512__checkpoints
+    type: clm
+    name: marin_llama_plantcad_600m_c512__fwd_rc_avg
+    context_length: 512
+    subfolder: local_store/checkpoints/plantcad-train-600m-r16-a1bc43/hf/step-26782
+    motif_inference_mode: fwd_rc_avg
+  - path: plantcad/marin_exp1729__pcv1_600m_c512__checkpoints
+    type: clm
+    name: marin_llama_plantcad_600m_c512__fwd_only
+    context_length: 512
+    subfolder: local_store/checkpoints/plantcad-train-600m-r16-a1bc43/hf/step-26782
+    motif_inference_mode: fwd_only
+  - path: plantcad/marin_exp1729__pcv1_600m_c512__checkpoints
+    type: clm
+    name: marin_llama_plantcad_600m_c512__rc_only
+    context_length: 512
+    subfolder: local_store/checkpoints/plantcad-train-600m-r16-a1bc43/hf/step-26782
+    motif_inference_mode: rc_only
 
 compute:
   device: cuda

--- a/src/pipelines/plantcad2/evaluation/pipeline.py
+++ b/src/pipelines/plantcad2/evaluation/pipeline.py
@@ -209,7 +209,7 @@ class EvaluationPipeline:
             task_config = step.config
             result_row = {
                 "dataset": task_config.repo_id,
-                "model": task_config.model_path,
+                "model": task_config.model_name,
                 "task": task_config.task,
                 "split": task_config.split,
                 **metrics,

--- a/src/pipelines/plantcad2/evaluation/tasks.py
+++ b/src/pipelines/plantcad2/evaluation/tasks.py
@@ -17,7 +17,7 @@ from src.utils.ray_utils import (
     run_once_per_node,
     run_on_exclusive_node,
 )
-from src.pipelines.plantcad2.evaluation.utils import (
+from src.pipelines.plantcad2.evaluation.core import (
     compute_core_noncore_scores,
     compute_evo_cons_probs,
     compute_motif_probs,
@@ -193,7 +193,6 @@ def evo_cons_task(config: EvoConsTaskConfig) -> None:
     )
     probs = probs_da.values
     n_examples = len(results.sample)
-    # Extract 1D variables for metrics computation
     results_df = pd.DataFrame(
         {
             config.seq_column: results[config.seq_column].values,

--- a/src/tests/pipelines/plantcad2/evaluation/test_core.py
+++ b/src/tests/pipelines/plantcad2/evaluation/test_core.py
@@ -1,0 +1,314 @@
+"""Tests for masked probability computation."""
+
+import contextlib
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+from unittest.mock import MagicMock, patch
+
+from src.pipelines.plantcad2.evaluation.config import (
+    EvoConsTaskConfig,
+    ModelType,
+    MotifInferenceMode,
+    MotifTaskConfig,
+)
+from src.pipelines.plantcad2.evaluation.core import (
+    center_crop_sequences,
+    compute_evo_cons_probs,
+    compute_motif_probs,
+    reverse_complement,
+    N_NUCLEOTIDES,
+    NUCLEOTIDES,
+)
+
+# Token IDs (offset from 0 to catch index bugs)
+TOKEN_A, TOKEN_C, TOKEN_G, TOKEN_T = 10, 11, 12, 13
+MASK_TOKEN = 99
+UNK_TOKEN = 0
+
+
+class MockTokenizer:
+    """Char-level tokenizer with offset token IDs."""
+
+    def __init__(self):
+        self._vocab = {"a": TOKEN_A, "c": TOKEN_C, "g": TOKEN_G, "t": TOKEN_T}
+        self.mask_token_id = MASK_TOKEN
+        self.unk_token_id = UNK_TOKEN
+
+    def get_vocab(self):
+        return self._vocab
+
+    def __call__(self, text, **kwargs):
+        if isinstance(text, list):
+            ids = [[self._vocab.get(c.lower(), UNK_TOKEN) for c in s] for s in text]
+            return {"input_ids": torch.tensor(ids)}
+        ids = [self._vocab.get(c.lower(), UNK_TOKEN) for c in text]
+        return {"input_ids": torch.tensor([ids])}
+
+
+class MockModel:
+    """Mock model that predicts T for motif_len positions after each A.
+
+    Logic:
+    - For each 'A' at position i, predict 'T' for positions i+1 through i+motif_len.
+    - Otherwise, predict 'C'.
+
+    For MLM: logits[pos] predicts token at pos.
+    For CLM: logits[pos] predicts token at pos+1 (next token prediction).
+    """
+
+    def __init__(self, motif_len: int, model_type: ModelType):
+        self.motif_len = motif_len
+        self.model_type = model_type
+
+    def eval(self):
+        pass
+
+    def to(self, **kwargs):
+        return self
+
+    def __call__(self, input_ids):
+        batch_size, seq_len = input_ids.shape
+        logits = torch.full((batch_size, seq_len, 100), -10.0)
+
+        for i in range(batch_size):
+            seq = input_ids[i]
+
+            # Find target positions where we want T predictions
+            t_positions = set()
+            for pos in range(seq_len):
+                if seq[pos] == TOKEN_A:
+                    for offset in range(1, self.motif_len + 1):
+                        if pos + offset < seq_len:
+                            t_positions.add(pos + offset)
+
+            # Set logits - for CLM, shift logit position back by 1
+            logit_offset = -1 if self.model_type == ModelType.clm else 0
+            for pos in range(seq_len):
+                logit_pos = pos + logit_offset
+                if logit_pos < 0:
+                    continue
+                if pos in t_positions:
+                    logits[i, logit_pos, TOKEN_T] = 10.0
+                else:
+                    logits[i, logit_pos, TOKEN_C] = 10.0
+
+        return MagicMock(logits=logits)
+
+
+@contextlib.contextmanager
+def mock_model(motif_len: int, model_type: ModelType = ModelType.mlm):
+    model_class = {
+        ModelType.mlm: "AutoModelForMaskedLM",
+        ModelType.clm: "AutoModelForCausalLM",
+    }[model_type]
+    with (
+        patch(
+            f"src.pipelines.plantcad2.evaluation.core.{model_class}.from_pretrained",
+            return_value=MockModel(motif_len, model_type),
+        ),
+        patch(
+            "src.pipelines.plantcad2.evaluation.core.AutoTokenizer.from_pretrained",
+            return_value=MockTokenizer(),
+        ),
+    ):
+        yield
+
+
+def _base_config(
+    mask_indexes: list[int],
+    model_type: ModelType = ModelType.mlm,
+    inference_mode: MotifInferenceMode = MotifInferenceMode.fwd_only,
+) -> dict:
+    return dict(
+        task="test",
+        split="test",
+        repo_id="test/repo",
+        model_path="test/model",
+        model_type=model_type,
+        model_context_length=8192,
+        model_name="test-model",
+        model_motif_inference_mode=inference_mode,
+        seq_length=8192,
+        device="cpu",
+        batch_size=4,
+        num_workers=None,
+        seq_column="sequence",
+        label_column="label",
+        mask_token_indexes=mask_indexes,
+        motif_len=len(mask_indexes),
+    )
+
+
+def _softmax_probs(*high_indices: int) -> list[float]:
+    """Return softmax probabilities with high logit at specified indices."""
+    logits = np.full(N_NUCLEOTIDES, -10.0)
+    for idx in high_indices:
+        logits[idx] = 10.0
+    exp = np.exp(logits - logits.max())
+    return (exp / exp.sum()).tolist()
+
+
+# Nucleotide indices in output probs
+A, C, G, T = [NUCLEOTIDES.index(n) for n in ("A", "C", "G", "T")]
+
+# Softmax probability vectors with high logit at the corresponding nucleotide
+pA, pC, pG, pT = [_softmax_probs(i) for i in (A, C, G, T)]
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        pytest.param(ModelType.mlm, id="mlm"),
+        pytest.param(ModelType.clm, id="clm"),
+    ],
+)
+def test_compute_evo_cons_probs(model_type):
+    # Seq 0: A at pos 1 -> predict T at pos 2 (mask position)
+    # Seq 1: no A -> predict C
+    # Seq 2: A at pos 0 only (left of trigger) -> A@0 triggers T at pos 1, C at pos 2
+    df = pd.DataFrame(
+        {
+            "example_idx": [0, 1, 2],
+            "sequence": ["CACCCC", "CCCCCC", "ACCCCC"],
+        }
+    )
+    config = EvoConsTaskConfig(**_base_config(mask_indexes=[2], model_type=model_type))
+
+    with mock_model(motif_len=1, model_type=model_type):
+        ids, probs = compute_evo_cons_probs(df, config)
+
+    expected = np.array([pT, pC, pC])
+    assert ids.tolist() == [0, 1, 2]
+    np.testing.assert_allclose(probs, expected, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "sequences,mask_indexes,expected",
+    [
+        pytest.param(
+            # Seq 0: A at pos 1 -> predict T at pos 2 (mask position)
+            # Seq 1: no A -> predict C
+            # Seq 2: A at pos 0 only -> A@0 triggers T at 1, C at mask pos 2
+            ["CACCCC", "CCCCCC", "ACCCCC"],
+            [2],
+            [[pT], [pC], [pC]],
+            id="1bp",
+        ),
+        pytest.param(
+            # Seq 0: A at pos 1 -> predict T at pos 2, 3 (mask positions)
+            # Seq 1: no A -> predict CC
+            # Seq 2: A at pos 0 only -> A@0 triggers T at 1,2 -> TC at masks
+            ["CACCCC", "CCCCCC", "ACCCCC"],
+            [2, 3],
+            [[pT, pT], [pC, pC], [pT, pC]],
+            id="2bp",
+        ),
+        pytest.param(
+            # Seq 0: A at pos 1 -> predict T at pos 2, 3, 4 (mask positions)
+            # Seq 1: no A -> predict CCC
+            # Seq 2: A at pos 0 only -> A@0 triggers T at 1,2,3 -> TTC at masks
+            ["CACCCCCC", "CCCCCCCC", "ACCCCCCC"],
+            [2, 3, 4],
+            [[pT, pT, pT], [pC, pC, pC], [pT, pT, pC]],
+            id="3bp",
+        ),
+    ],
+)
+def test_compute_motif_probs(sequences, mask_indexes, expected):
+    df = pd.DataFrame({"example_idx": [0, 1, 2], "sequence": sequences})
+    config = MotifTaskConfig(**_base_config(mask_indexes=mask_indexes))
+    motif_len = len(mask_indexes)
+
+    with mock_model(motif_len=motif_len):
+        ids, probs = compute_motif_probs(df, config)
+
+    assert ids.tolist() == [0, 1, 2]
+    assert probs.shape == (3, motif_len, N_NUCLEOTIDES)
+    np.testing.assert_allclose(probs, np.array(expected), atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "inference_mode,sequences,expected",
+    [
+        pytest.param(
+            # fwd_only: A at pos 2 triggers T at mask pos 3
+            MotifInferenceMode.fwd_only,
+            ["CCACCCC", "CCCCCCC", "CACCCCC"],
+            [pT, pC, pC],
+            id="fwd_only",
+        ),
+        pytest.param(
+            # rc_only: RC'd inputs get RC'd back by core.py, mock predicts [pT, pC, pC],
+            # then _flip_rc_probs swaps complements: T->A, C->G
+            MotifInferenceMode.rc_only,
+            ["GGGGTGG", "GGGGGGG", "GGGGGTG"],  # RC of fwd sequences
+            [pA, pG, pG],
+            id="rc_only",
+        ),
+    ],
+)
+def test_clm_motif_inference_mode(inference_mode, sequences, expected):
+    # 7-char sequences with centered mask at pos 3 (odd length so RC preserves center)
+    df = pd.DataFrame({"example_idx": [0, 1, 2], "sequence": sequences})
+    config = MotifTaskConfig(
+        **_base_config(
+            mask_indexes=[3], model_type=ModelType.clm, inference_mode=inference_mode
+        )
+    )
+
+    with mock_model(motif_len=1, model_type=ModelType.clm):
+        ids, probs = compute_motif_probs(df, config)
+
+    assert ids.tolist() == [0, 1, 2]
+    np.testing.assert_allclose(probs.squeeze(), np.array(expected), atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "seq,seq_length,context_length,expected",
+    [
+        pytest.param("AABBCC", 6, 2, "BB", id="6_to_2"),
+        pytest.param("AABBBBCC", 8, 4, "BBBB", id="8_to_4"),
+        pytest.param("AABBBBCC", 8, 6, "ABBBBC", id="8_to_6"),
+        pytest.param("AABBBBCC", 8, 8, "AABBBBCC", id="no_crop"),
+        pytest.param("AABBBBCC", 8, 10, "AABBBBCC", id="context_exceeds_seq"),
+        pytest.param(
+            "A" * 3840 + "B" * 512 + "C" * 3840,
+            8192,
+            512,
+            "B" * 512,
+            id="8192_to_512",
+        ),
+    ],
+)
+def test_center_crop_sequences(seq, seq_length, context_length, expected):
+    df = pd.DataFrame({"seq": [seq]})
+    result = center_crop_sequences(df, "seq", seq_length, context_length)
+    assert result["seq"].iloc[0] == expected
+
+
+@pytest.mark.parametrize(
+    "seq_length,context_length",
+    [
+        pytest.param(7, 4, id="odd_seq_length"),
+        pytest.param(8, 5, id="odd_context_length"),
+        pytest.param(7, 5, id="both_odd"),
+    ],
+)
+def test_center_crop_sequences_rejects_odd_lengths(seq_length, context_length):
+    df = pd.DataFrame({"seq": ["A" * seq_length]})
+    with pytest.raises(ValueError, match="Both lengths must be even"):
+        center_crop_sequences(df, "seq", seq_length, context_length)
+
+
+def test_reverse_complement():
+    rc = reverse_complement
+    assert rc("ACGT") == "ACGT"
+    assert rc("AAAA") == "TTTT"
+    assert rc("CCGG") == "CCGG"
+    assert rc("GcTA") == "TAgC"
+    assert rc("acgt") == "acgt"
+    assert rc("N") == "N"
+    assert rc("ANCGT") == "ACGNT"
+    assert rc(rc("ANCGTancgt")) == "ANCGTancgt"

--- a/src/tests/pipelines/plantcad2/evaluation/test_pipeline.py
+++ b/src/tests/pipelines/plantcad2/evaluation/test_pipeline.py
@@ -1,0 +1,25 @@
+import pytest
+
+from src.pipelines.plantcad2.evaluation.pipeline import align_mask_indexes
+
+
+def test_align_mask_indexes_no_adjustment():
+    defaults = {"mask_token_indexes": [4095], "motif_len": 1}
+    result = align_mask_indexes(defaults, model_context_length=8192, seq_length=8192)
+    assert result == defaults
+
+
+def test_align_mask_indexes_downscale_8192_to_512():
+    # Original indexes centered in 8192: [4094, 4095, 4096]
+    # Offset = (8192 - 512) // 2 = 3840
+    # New indexes = [4094 - 3840, 4095 - 3840, 4096 - 3840] = [254, 255, 256]
+    defaults = {"mask_token_indexes": [4094, 4095, 4096], "motif_len": 3}
+    result = align_mask_indexes(defaults, model_context_length=512, seq_length=8192)
+    assert result["mask_token_indexes"] == [254, 255, 256]
+    assert result["motif_len"] == 3
+
+
+def test_align_mask_indexes_raises_when_mask_token_indexes_missing():
+    defaults = {"motif_len": 1}
+    with pytest.raises(ValueError, match="mask_token_indexes required"):
+        align_mask_indexes(defaults, model_context_length=512, seq_length=8192)


### PR DESCRIPTION
This adds support for casual LMs on all PlantCAD2 zero-shot tasks except for SV ranking (for now).  I used the final [checkpoint](https://huggingface.co/plantcad/marin_exp1729__pcv1_600m_c512__checkpoints/tree/main/local_store/checkpoints/plantcad-train-600m-r16-a1bc43/hf/step-26782) from https://github.com/marin-community/marin/issues/1729 to test these new implementations.  In order to compare that model with a context length of 512bp, I also had to add support for center-cropping eval sequences down to a length compatible with any context length.  Here are some results I'm seeing for 15 evals on that model vs the smallest and largest PlantCAD1 models:

<p align="center">
<strong>CLM vs MLM PlantCAD2 zero-shot eval performance</strong>
</p>

<img width="1107" height="904" alt="eval_results" src="https://github.com/user-attachments/assets/3c1b66da-7e82-4c77-9777-73bdfc633779" />

*source*: [eval_results.pdf](https://github.com/user-attachments/files/23866421/eval_results.pdf) | [eval_results.py.zip](https://github.com/user-attachments/files/23866418/eval_results.py.zip)

Notes: 

- The CLM model is fairly comparable to both PlantCAD1 models in 2 of 3 cross-species conservation tasks (`conservation_within_*`)
  - For the non-TIS conservation task, the performance deficit vs `PlantCAD1-L` ("plantcad1-large" above) is similar to the one in https://github.com/marin-community/marin/issues/1729, as is the performance gain vs `PlantCAD1-S`
  -  Performance is very poor on the TIS-specific task `conservation_within_poaceae_tis`, which is consistent with poor performance on all the other TIS tasks
- I see the same relationship between forward vs RC processing and tasks best suited to each as @zhaijj did with Evo 2 in the PC2 [paper](https://www.biorxiv.org/content/10.1101/2025.08.27.672609v2.full.pdf) (figure 3)
  - The `fwd-only` mode does much better on TTS and donor prediction
  - The `rc-only` mode does much better on TIS and acceptor prediction
- I've added forward-only, RC-only and averaging modes (`fwd-rc-avg`) for the way motif probabilities are generated (as in the legend)
  - The `fwd-rc-avg` is as good or better than either uni-directional approach in ~12 of 15 evals, so that is the default
- The hard token/motif classification performance is really poor by comparison to PlantCAD1, but I think there's a good chance that performance would emerge as a sigmoid of some more linear capability
  - Perhaps the generic conservation scores are a good proxy for that continuous, linear improvement?
- All tasks were run on the `maize` splits, except for the cross-species tasks (see [here](https://github.com/plantcad/plantcad-dev/blob/1309da3ba30275cb4045bc03d483a4cba5da5b9f/src/pipelines/plantcad2/evaluation/config.yaml))
- All tasks were run with a random sample of 5k examples

I'd like to validate these implementations with a better positive control model, i.e. I'd like to see CLM performance match PlantCAD.  I'll continue working towards that with a more systematic approach, e.g. as in https://github.com/marin-community/marin/issues/2101.  Regardless, I've added some solid testing of the core logic related to motif detection for both CLMs and MLMs in [src/tests/pipelines/plantcad2/evaluation/test_core.py](https://github.com/plantcad/plantcad-dev/blob/1309da3ba30275cb4045bc03d483a4cba5da5b9f/src/tests/pipelines/plantcad2/evaluation/test_core.py).  This covers the most important bits for all PC2 zero-shot tasks other than the one for structural variants.

I'll also note that the pipeline supports evaluating multiple models at once which is a nice convenience for experiments like this (w/o per-job start/stop overhead).  E.g. individual models to evaluate can be configured like this:

```yaml
models:
  - path: plantcad/marin_exp1729__pcv1_600m_c512__checkpoints
    type: clm
    name: marin_llama_plantcad_600m_c512
    context_length: 512
    subfolder: local_store/checkpoints/plantcad-train-600m-r16-a1bc43/hf/step-26782
    motif_inference_mode: fwd_rc_avg
```

---

<details><summary>Commands I ran</summary>

```bash
aws sso login --profile default
aws configure export-credentials --profile default --format env | source /dev/stdin

sky launch -c pc-dev configs/skypilot/cluster.sky.yaml --gpus H100 --num-nodes 1 \
  --env HUGGING_FACE_HUB_TOKEN \
  --env AWS_ACCESS_KEY_ID \
  --env AWS_SECRET_ACCESS_KEY \
  --env AWS_SESSION_TOKEN

TASK_MODULE=src.pipelines.plantcad2.evaluation.pipeline \
TASK_CONFIG=src/pipelines/plantcad2/evaluation/config.yaml \
TASK_ARGS="--sampling.max_size=5000" \
RAY_DEDUP_LOGS=0 \
RAY_SCHEDULER_EVENTS=0 \
sky exec pc-dev configs/skypilot/task.sky.yaml \
    --num-nodes 1 --env HUGGING_FACE_HUB_TOKEN \
    --env TASK_MODULE --env TASK_CONFIG --env TASK_ARGS --env RAY_DEDUP_LOGS \
    --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN

# S3 commands for post-hoc analysis and manipulation of executor prefixes (i.e. to rerun pipeline or step)
aws s3 rm --recursive s3://oa-plantcad-dev/pipelines/_dev_pc2_eval_20251201_r1
aws s3 ls --recursive s3://oa-plantcad-dev/pipelines/_dev_pc2_eval_20251201_r1
aws s3 cp s3://oa-plantcad-dev/pipelines/_dev_pc2_eval_20251201_r1/tts_recovery__test_maize__marin_exp1729__pcv1_600m_c512__checkpoints-6e2049/predictions.nc .
```

</details>


TODO:

- [ ] Review change of default prob aggregation to products
